### PR TITLE
Eliminate warning in Ruby 2.7

### DIFF
--- a/lib/open_exchange_rates/rates.rb
+++ b/lib/open_exchange_rates/rates.rb
@@ -102,7 +102,7 @@ module OpenExchangeRates
 
     def parse_on(date_string)
       @on_parser = OpenExchangeRates::Parser.new
-      @on_parser.parse(open("#{OpenExchangeRates::BASE_URL}/historical/#{date_string}.json?app_id=#{@app_id}"))
+      @on_parser.parse(URI.open("#{OpenExchangeRates::BASE_URL}/historical/#{date_string}.json?app_id=#{@app_id}"))
     end
 
   end

--- a/lib/open_exchange_rates/rates.rb
+++ b/lib/open_exchange_rates/rates.rb
@@ -93,7 +93,7 @@ module OpenExchangeRates
       @latest_parser ||= OpenExchangeRates::Parser.new
       if Object.const_defined?('Rails') && Rails.respond_to?(:cache)
         Rails.cache.fetch("open_exchange_rates", expires_in: 1.hour) do
-          @latest_parser.parse(open("#{OpenExchangeRates::LATEST_URL}?app_id=#{@app_id}"))
+          @latest_parser.parse(URI.open("#{OpenExchangeRates::LATEST_URL}?app_id=#{@app_id}"))
         end
       else
         @latest_parser.parse(open("#{OpenExchangeRates::LATEST_URL}?app_id=#{@app_id}"))


### PR DESCRIPTION
Users/chuck/.rvm/gems/ruby-2.7.5/bundler/gems/open_exchange_rates-fdd153d9d3bc/lib/open_exchange_rates/rates.rb:96: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open